### PR TITLE
Pure fix for homedecor_3d_extras issue

### DIFF
--- a/depends.txt
+++ b/depends.txt
@@ -1,3 +1,4 @@
 default
 doors
 mesecon?
+homedecor_3d_extras?


### PR DESCRIPTION
Fixes #28 
Optionally depend on homedecor_3d_extras to override its overrides